### PR TITLE
Fix ecr syntax activation

### DIFF
--- a/grammars/html (crystal - ecr).cson
+++ b/grammars/html (crystal - ecr).cson
@@ -1,4 +1,4 @@
-fileType: [
+fileTypes: [
   'ecr'
   'html.ecr'
 ]


### PR DESCRIPTION
My `.ecr` files were always being detected as "Plain Text". This change allows Atom to properly activate the "HTML (Crystal - ECR)" grammar for them.