### PR TITLE
Added *out*, *pointerof*, *sizeof* and *typeof* to keywords

### DIFF
--- a/grammars/crystal.cson
+++ b/grammars/crystal.cson
@@ -105,7 +105,7 @@ patterns: [
   }
   {
     comment: ' just as above but being not a logical operation'
-    match: '(?<!\\.)\\b(alias|alias_method|break|next|redo|retry|return|super|type|undef|yield)\\b(?![?!])|\\bdefined\\?|\\bblock_given\\?'
+    match: '(?<!\\.)\\b(alias|alias_method|break|next|redo|retry|return|super|type|undef|yield|out|pointerof|typeof)\\b(?![?!])|\\bdefined\\?|\\bblock_given\\?'
     name: 'keyword.control.pseudo-method.crystal'
   }
   {


### PR DESCRIPTION
I noticed there wasn't any highlighting for these when working with C bindings, and thought I'd see if you guys want them as keywords here. Is keywords the status place for them? This is what they seem to be in the [GitBook](https://crystal-lang.org/docs/syntax_and_semantics/c_bindings/out.html)'s highlighting.