### PR TITLE
fix: naming of lib definitions

### DIFF
--- a/grammars/crystal.cson
+++ b/grammars/crystal.cson
@@ -65,7 +65,7 @@ patterns: [
       2:
         name: 'entity.name.type.lib.crystal'
     match: '^\\s*(lib)\\s+([.\\w\\d_]+)'
-    name: 'meta.module.crystal'
+    name: 'meta.lib.crystal'
   }
   {
     captures:


### PR DESCRIPTION
Fixes an issue where lib definitions would be incorrectly tagged as `meta.module.crystal`.